### PR TITLE
Improve windows support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ ifeq ($(TARGET_OS),win32)
 	COPY_CMD = copy
 	RM_CMD = del /Q /F
 	MKDIR_CMD = mkdir
+	RMDIR_CMD = rmdir /Q /S
 	CMDQUIET = >nul 2>nul & verify >nul
 	PATH_SEP = \\
 else
@@ -43,6 +44,7 @@ else
 	COPY_CMD = cp
 	RM_CMD = rm -f
 	MKDIR_CMD = mkdir -p
+	RMDIR_CMD = rm -rf
 	PATH_SEP = /
 endif
 
@@ -115,7 +117,11 @@ $(DIST_DIR):
 clean:
 	@$(RM_CMD) $(TARGET) $(OBJ) $(DIFF_FILES) $(CMDQUIET)
 
+fullclean:
+	@$(RM_CMD) $(TARGET) $(OBJ) $(DIFF_FILES) $(DIST_ARCHIVE) $(CMDQUIET)
+	@$(RMDIR_CMD) $(DIST_DIR) $(CMDQUIET)
+
 format-check: $(DIFF_FILES)
 	@$(RM_CMD) $(DIFF_FILES)
 
-.PHONY: all clean dist format-check
+.PHONY: all clean fullclean dist format-check

--- a/Makefile
+++ b/Makefile
@@ -34,12 +34,14 @@ ifeq ($(TARGET_OS),win32)
 	FILES_TO_FORMAT := $(shell for /f "delims=" %%i in ('dir /s /b *.c *.cpp ^| findstr /v /i littlefs') do @echo %%i)
 	COPY_CMD = copy
 	RM_CMD = del /Q /F
+	MKDIR_CMD = mkdir
 	PATH_SEP = \\
 else
 	TARGET := mklittlefs
 	FILES_TO_FORMAT := $(shell find . -not -path './littlefs/*' \( -name '*.c' -o -name '*.cpp' \))
 	COPY_CMD = cp
 	RM_CMD = rm -f
+	MKDIR_CMD = mkdir -p
 	PATH_SEP = /
 endif
 
@@ -107,7 +109,7 @@ $(TARGET): $(OBJ)
 	$(STRIP) $(TARGET)
 
 $(DIST_DIR):
-	@mkdir -p $@
+	@$(MKDIR_CMD) $@
 
 clean:
 	@$(RM_CMD) $(TARGET) $(OBJ) $(DIFF_FILES)

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ ifeq ($(TARGET_OS),win32)
 	COPY_CMD = copy
 	RM_CMD = del /Q /F
 	MKDIR_CMD = mkdir
+	CMDQUIET = >nul 2>nul & verify >nul
 	PATH_SEP = \\
 else
 	TARGET := mklittlefs
@@ -112,7 +113,7 @@ $(DIST_DIR):
 	@$(MKDIR_CMD) $@
 
 clean:
-	@$(RM_CMD) $(TARGET) $(OBJ) $(DIFF_FILES)
+	@$(RM_CMD) $(TARGET) $(OBJ) $(DIFF_FILES) $(CMDQUIET)
 
 format-check: $(DIFF_FILES)
 	@$(RM_CMD) $(DIFF_FILES)


### PR DESCRIPTION
This PR fixes some minor issues in windows:
- removes `-p` from `mkdir` command.  in windows `mkdir` creates parents by default and does not need any switch. by adding `-p` it will create a folder named `-p`
- makes `del` command quiet like `rm`. it will not complain about not found files in clean

Also adds a `fullclean` command for all OSs to clean folders and tar files that are created by `make dist`